### PR TITLE
Adding to the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 pkg
 .idea/
+coverage/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,7 @@ gemspec
 group :development do
   gem 'cocoapods'
   gem 'bacon'
+  gem 'prettybacon'
+  gem 'coveralls', require: false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'pathname'
 ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 $:.unshift((ROOT + 'lib').to_s)
@@ -5,6 +8,7 @@ $:.unshift((ROOT + 'spec').to_s)
 
 require 'bundler/setup'
 require 'bacon'
+require 'pretty_bacon'
 require 'cocoapods'
 
 require 'cocoapods_plugin'


### PR DESCRIPTION
cocoapods-label creates a descriptive annotation for each pod so you don't have to guess what each podfile does.
